### PR TITLE
Fix filter application timing

### DIFF
--- a/LetMeBuyIt.lua
+++ b/LetMeBuyIt.lua
@@ -1,5 +1,12 @@
 local f=CreateFrame("Frame")
+local ticker
 f:SetScript("OnEvent", function(self, event)
-	MerchantFrame_SetFilter(MerchantFrame, 1)
+	ticker = C_Timer.NewTicker(0, function()
+		local frameVisible = MerchantFrame:IsVisible()
+		if frameVisible then
+			MerchantFrame_SetFilter(MerchantFrame, 1)
+			ticker:Cancel()
+		end
+	end)
 end)
 f:RegisterEvent("MERCHANT_SHOW")

--- a/LetMeBuyIt.toc
+++ b/LetMeBuyIt.toc
@@ -1,4 +1,4 @@
-## Interface: 70300
+## Interface: 100100
 
 ## Title: LetMeBuyIt
 ## Notes: Sets all Mechant Filters to "All"


### PR DESCRIPTION
Since MERCHANT_SHOW fires before the frame is visible and Blizzard's filtering hasn't been applied yet, by waiting until after MerchantFrame is visible, this effectively resolves the timing problem. Using a ticket does this with minimal resource consumption